### PR TITLE
Use normal colons in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,9 +53,9 @@ Read pcap:
 
 
     for len, t, pkt in rpcap("tests/dns.pcap"):
-        print("Buf length：", len)
-        print("Time：", t)
-        print("Buf：", pkt)
+        print("Buf length:", len)
+        print("Time:", t)
+        print("Buf:", pkt)
 
 Write pcap:
 


### PR DESCRIPTION
This was breaking pip installs (!): 

# pip3 install python-libpcap==0.1.3
Collecting python-libpcap==0.1.3
  Using cached https://files.pythonhosted.org/packages/f1/47/e631fa7e12582c40d0237ff10e6497c08c68b92160cee8c30115d22c3704/python-libpcap-0.1.3.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-cu_fnxgv/python-libpcap/setup.py", line 12, in <module>
        long_description = f.read()
      File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xef in position 1133: ordinal not in range(128)