### PR TITLE
Add pyproject.toml with PEP-517 build system

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,6 @@ To install python-libpcap, run this command in your terminal:
 .. code-block:: console
 
     $ sudo apt-get install libpcap-dev
-    $ pip3 install Cython
     $ pip3 install python-libpcap
 
 Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "Cython"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
python-libpcap depends on Cython to build, but doesn't specify this build dependency, just documents it in README.rst. This may work if you install the package into an environment using pip directly, and install Cython first, but it does not work when using tools which perform builds in isolated environments, such as PDM, or even just using pip to install if you don't first install Cython.

Add a pyproject.toml with PEP-517 build backend and build requires to properly be able to build this using tools which install build dependencies automatically.